### PR TITLE
feat(filter): Add maximum characters count limit.

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,4 +1,5 @@
 AutoSub.FilterName="Auto Subtitle Filter"
+AutoSub.MaxCharCount="Maximum Characters Shown"
 AutoSub.ServiceProvider="Service Provider"
 AutoSub.APPID="App ID"
 AutoSub.APIKEY="Api Key"

--- a/data/locale/zh-CN.ini
+++ b/data/locale/zh-CN.ini
@@ -1,4 +1,5 @@
 ﻿AutoSub.FilterName="自动字幕"
+AutoSub.MaxCharCount="最大字符数"
 AutoSub.ServiceProvider="服务提供商"
 AutoSub.APPID="App ID"
 AutoSub.APIKEY="Api Key"


### PR DESCRIPTION
Some cloud service split sentence too insensitive, so we need to
limit the maximum count to make sure not display too much at a
time.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>