### PR TITLE
feat(alinls): Auto restart when connect timeout.

### DIFF
--- a/src/vendor/AliNLS.cpp
+++ b/src/vendor/AliNLS.cpp
@@ -117,7 +117,11 @@ void AliNLS::onTextMessageReceived(const QString message) {
         ok = true;
     } else {
         auto status = doc["header"]["status"].toInt();
-        if(status != 20000000) {
+        if(status == 40000004) {
+            running = false;
+            ws.close();
+            emit start();
+        } else if(status != 20000000) {
             auto cb = getErrorCallback();
             if(cb) {
                 cb(ERROR_API, doc["header"]["status_text"].toString());


### PR DESCRIPTION
Sometimes obs don't give audio data so we failed to send.
Just reconnect when timeout.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>