### PR TITLE
fix(package): Bundle TLS with plugin on macOS.

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -216,6 +216,7 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
           -DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET:-10.15}
           -DOBS_CODESIGN_LINKER=ON
           -DOBS_BUNDLE_CODESIGN_IDENTITY="${CODESIGN_IDENT:--}"
+          -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)"
         )
         num_procs=$(( $(sysctl -n hw.ncpu) + 1 ))
         ;;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PLUGIN_NAME }}-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
-          path: ${{ github.workspace }}/plugin/release/${{ env.PLUGIN_NAME }}-*-macos-${{ matrix.arch }}.pkg
+          path: ${{ github.workspace }}/plugin/release/
 
   linux_build:
     name: 02 - Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,18 @@ if(OS_MACOS)
     DESTINATION "./${CMAKE_PROJECT_NAME}.plugin/Contents/Frameworks"
     COMPONENT obs_plugins
     PATTERN "Headers" EXCLUDE)
+  install(
+    DIRECTORY "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_PLUGINS}/tls"
+    DESTINATION "./${CMAKE_PROJECT_NAME}.plugin/Contents/PlugIns"
+    COMPONENT obs_plugins)
+
+  find_package(OpenSSL REQUIRED)
+
+  install(
+    FILES ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY}
+    DESTINATION "./${CMAKE_PROJECT_NAME}.plugin/Contents/Frameworks"
+    COMPONENT obs_plugins)
+
   if(${QT_VERSION} EQUAL 5)
     set(_QT_FW_VERSION "${QT_VERSION}")
   else()
@@ -138,6 +150,7 @@ if(OS_MACOS)
   set(_COMMAND
       "${CMAKE_INSTALL_NAME_TOOL} \\
         -change @rpath/QtWebSockets.framework/Versions/${_QT_FW_VERSION}/QtWebSockets @loader_path/../Frameworks/QtWebSockets.framework/Versions/${_QT_FW_VERSION}/QtWebSockets \\
+        -add_rpath @loader_path/../Frameworks \\
         \\\"\${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}.plugin/Contents/MacOS/${CMAKE_PROJECT_NAME}\\\""
   )
   install(CODE "execute_process(COMMAND /bin/sh -c \"${_COMMAND}\")" COMPONENT obs_plugins)

--- a/cmake/bundle/macos/installer-macos.pkgproj.in
+++ b/cmake/bundle/macos/installer-macos.pkgproj.in
@@ -538,7 +538,7 @@
 			<key>TYPE</key>
 			<integer>0</integer>
 			<key>UUID</key>
-			<string>0B7A74BC-65CF-4FF1-AC34-5C743E8A48F5</string>
+			<string>BF4F3557-0073-4E5E-8C76-12C3BC288F71</string>
 		</dict>
 	</array>
 	<key>PROJECT</key>
@@ -584,13 +584,13 @@
 									<integer>1</integer>
 								</dict>
 								<key>PACKAGE_UUID</key>
-								<string>0B7A74BC-65CF-4FF1-AC34-5C743E8A48F5</string>
+								<string>BF4F3557-0073-4E5E-8C76-12C3BC288F71</string>
 								<key>TITLE</key>
 								<array/>
 								<key>TYPE</key>
 								<integer>0</integer>
 								<key>UUID</key>
-								<string>52B6084A-F58D-45C3-BE37-76AD45F16072</string>
+								<string>D8FBC071-434F-4D33-BC0E-1B09751EB132</string>
 							</dict>
 						</array>
 						<key>REMOVED</key>

--- a/cmake/bundle/windows/installer-Windows.iss.in
+++ b/cmake/bundle/windows/installer-Windows.iss.in
@@ -7,7 +7,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{CD703FE5-1F2C-4837-BD3D-DD840D83C3E3}
+AppId={{BEFF9830-F7CF-4DA6-BA9A-9D12C9D9AEF8}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}


### PR DESCRIPTION
QtWebsockets need openssl support to connect to wss:// websocket, But neither macOS nor obs-studio has openssl. So we carry our owns.

Signed-off-by: Yibai Zhang <xm1994@gmail.com>