### PR TITLE
fix(QWebsocketpp): Fix crash caused by invalid state

### DIFF
--- a/src/util/QWebsocketpp/QWebsocketpp.h
+++ b/src/util/QWebsocketpp/QWebsocketpp.h
@@ -72,6 +72,7 @@ private:
 	websocketpp::connection_hdl hdl;
 	QString cacert_path;
 	bool running = false;
+	std::mutex running_lck;
 };
 
 #endif


### PR DESCRIPTION
We not properly handled the websocketpp connected state. Add running indicator and lock indicate that current status is connected.