### PR TITLE
fix(CI): Disable macos notarize

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -43,7 +43,7 @@ jobs:
             push)
               config_data=('codesign:true' 'notarize:false' 'package:true' 'config:RelWithDebInfo')
               if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.[0-9]+(-(rc|beta).+)? ]]; then
-                config_data[1]='notarize:true'
+                config_data[1]='notarize:false'
                 config_data[3]='config:Release'
               fi
               ;;


### PR DESCRIPTION
Since we don't have money to pay for a developer certificate, Disable notarize and let user at more risk.